### PR TITLE
Invert `mms` bool (bugfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you execute this example, the `sms_data` variable will contain a dictionary w
     'udhi': False,
     'sri': False,
     'lp': False,
-    'mms': True,
+    'mms': False,
     'mti': 'deliver'
   },
   'sender': {

--- a/smspdudecoder/fields.py
+++ b/smspdudecoder/fields.py
@@ -111,7 +111,7 @@ class PDUHeader:
         Decodes an incomming PDU header.
 
         >>> PDUHeader.decode(StringIO('44'))
-        {'rp': False, 'udhi': True, 'sri': False, 'lp': False, 'mms': True, 'mti': 'deliver'}
+        {'rp': False, 'udhi': True, 'sri': False, 'lp': False, 'mms': False, 'mti': 'deliver'}
         """
         result = dict()
         io_data = BitStream(hex=pdu_data.read(2))
@@ -124,7 +124,7 @@ class PDUHeader:
         # Loop Prevention
         result['lp'] = io_data.read('bool')
         # More Messages to Send
-        result['mms'] = io_data.read('bool')
+        result['mms'] = not io_data.read('bool')
         # Message Type Indicator
         result['mti'] = cls.MTI.get(io_data.read('bits:2').uint)
         if result['mti'] is None:


### PR DESCRIPTION
I noticed that given a SMS PDU, the `mms` bool was `True`, and given a MMS PDU, the `mms` bool was `False`:
```python3
from io import StringIO

sms_pdu = '07919107739667F9040B916128126946F900004221134174800A1554747A0E4ACF4161D0B43905B5CBF379F85C06'

mms_pdu = '07919107739667F9400A81111103010000044221134194920A8C0B05040B8423F000034002012D06226170706C69636174696F6E2F766E642E7761702E6D6D732D6D65737361676500AF848C8298414C4C423032303531323331313934393239323232303035303030313130303030008D918918802B31363832323139363634392F545950453D504C4D4E009602EA0086818A808E020FB18805810303F48083687474703A2F'


from smspdudecoder.fields import SMSDeliver
from smspdudecoder_patched.fields import SMSDeliver as SMSDeliverPatched

print(SMSDeliver.decode(StringIO(sms_pdu)))
print(SMSDeliverPatched.decode(StringIO(sms_pdu)))
print(SMSDeliver.decode(StringIO(mms_pdu)))
print(SMSDeliverPatched.decode(StringIO(mms_pdu)))
```

Shown above this small fix makes it a little more clear what is and is not a MMS PDU!

If there is any changes needed from me to get this merged in please let me know!